### PR TITLE
Refactor tests

### DIFF
--- a/tests/PhingTesterIntegrationTest.php
+++ b/tests/PhingTesterIntegrationTest.php
@@ -13,9 +13,9 @@ class PhingTesterIntegrationTest extends \PHPUnit\Framework\TestCase
 	{
 		$tester = new PhingTester(__DIR__ . '/phing-tester-integration-test.xml');
 		$target = __FUNCTION__;
-		$tester->executeTarget($target);
 
-		$this->assertTrue(true); // build should not fail and reach this
+		$this->expectNotToPerformAssertions();
+		$tester->executeTarget($target);
 	}
 
 	public function testMessageInLogs(): void

--- a/tests/PhingTesterIntegrationTest.php
+++ b/tests/PhingTesterIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\Phing\PhingTester;
 
+use PHPUnit\Framework\Assert;
 use Project;
 
 class PhingTesterIntegrationTest extends \PHPUnit\Framework\TestCase
@@ -101,7 +102,7 @@ class PhingTesterIntegrationTest extends \PHPUnit\Framework\TestCase
 		$tester = new PhingTester(__DIR__ . '/phing-tester-integration-test.xml');
 		$target = __FUNCTION__;
 		$tester->expectFailedBuild($target, function (\BuildException $e) use ($target): void {
-			$this->assertRegExp(sprintf('~%s.+not.+exist~', $target), $e->getMessage());
+			Assert::assertRegExp(sprintf('~%s.+not.+exist~', $target), $e->getMessage());
 		});
 	}
 
@@ -127,7 +128,7 @@ class PhingTesterIntegrationTest extends \PHPUnit\Framework\TestCase
 		$target = __FUNCTION__;
 		$tester->executeTarget($target);
 
-		$this->assertSame('bar', $tester->getProject()->getProperty('foo'));
+		Assert::assertSame('bar', $tester->getProject()->getProperty('foo'));
 	}
 
 }


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks